### PR TITLE
usefull statusbar, major changes to plasmid GUI selection

### DIFF
--- a/dna.py
+++ b/dna.py
@@ -33,6 +33,7 @@
 import fasta
 import string
 import random
+import protein # for conversion from dna to amino acid name
 
 
 ############# Basic DNA functions #####################

--- a/dnaeditor_GUI.py
+++ b/dnaeditor_GUI.py
@@ -389,23 +389,34 @@ class TextEdit(DNApyBaseClass):
 ######################################################
 
 	def OnLeftDown(self, event):
+		
 		event.Skip() #very important to make the event propagate and fulfill its original function
 
 	def OnLeftUp(self, event):
 		self.set_dna_selection() #update the varable keeping track of DNA selection
+		self.set_cursor_position() # update cursor position
 		event.Skip() #very important to make the event propagate and fulfill its original function		
 
 	def OnMotion(self, event):
-		#if event.Dragging() and event.LeftIsDown():
-		#	self.set_dna_selection() #update the varable keeping track of DNA selection
+		if event.Dragging() and event.LeftIsDown():
+			oldSel = genbank.dna_selection
+			if oldSel != self.get_selection():
+				self.set_dna_selection() #update the varable keeping track of DNA selection
+		
+		
 		event.Skip() #very important to make the event propagate and fulfill its original function
+
 
 	def OnRightUp(self, event):
 		print('dna right up')
 		event.Skip() #very important to make the event propagate and fulfill its original function
 
 #####################################################################
-
+	
+	def set_cursor_position(self):
+		# set position of cursor for status bar:
+		genbank.cursor_position = self.stc.GetCurrentPos()+1 # +1 because we have no 0 position, A|CGA is pos 2
+		
 	def set_dna_selection(self):
 		'''
 		Updates DNA selection.
@@ -482,6 +493,8 @@ class TextEdit(DNApyBaseClass):
 			self.stc.LineDownExtend()
 
 		self.set_dna_selection() #update the varable keeping track of DNA selection
+		
+		self.set_cursor_position() # udpate cursor position, just in case
 
 ##########################
 	def make_outputpopup(self):
@@ -774,7 +787,7 @@ if __name__ == '__main__': #if script is run by itself and not loaded
 	settings=files['default_dir']+"settings"   ##path to the file of the global settings
 	execfile(settings) #gets all the pre-assigned settings
 
-	genbank.dna_selection = (1, 1)	 #variable for storing current DNA selection
+	genbank.dna_selection = (1, -1)	 #variable for storing current DNA selection
 	genbank.feature_selection = False #variable for storing current feature selection
 	genbank.search_hits = []
 	

--- a/featurelist_GUI.py
+++ b/featurelist_GUI.py
@@ -198,7 +198,7 @@ class FeatureList(DNApyBaseClass):
 		locations = genbank.gb.get_feature_location(index)
 		start = genbank.gb.get_location(locations[0])[0]
 		finish = genbank.gb.get_location(locations[-1])[1]
-		genbank.dna_selection = copy.copy((start-1, finish))
+		genbank.dna_selection = copy.copy((start, finish))
 		self.update_globalUI()
 
 ######
@@ -346,7 +346,7 @@ if __name__ == '__main__': #if script is run by itself and not loaded
 	settings=files['default_dir']+"settings"   ##path to the file of the global settings
 	execfile(settings) #gets all the pre-assigned settings
 
-	genbank.dna_selection = (1, 1)	 #variable for storing current DNA selection
+	genbank.dna_selection = (1, -1)	 #variable for storing current DNA selection
 	genbank.feature_selection = False #variable for storing current feature selection
 
 	import sys


### PR DESCRIPTION
I wanted to make the statusbar work again. With this commit it can show:
- cursor position
- selection if any
- amino acid name (if triplet is selected)
- peptide sequence if more codons are selected

Related to the statusbar I improved selection in the cairo plasmid GUI. It was buggy and did not use genbank.selection. It now does.
Also I removed some helper variables to improve readability. It is now more easy to understand.

In plasmid GUI:
- I removed the two dark lines at the edge of the selected area, cause less is more
- outline of features is now only shown on hover as outline had no other use than indicating the area of selection
 - selection is indicated by blue selection...
- add double click to edit feature

I hope this commit is compatible with your work. if not so, please let me know. I would than fit the code to the new code base.

I also changed the "no selection" status to "genbank.dna_selection = (1, -1)" in every file. I think that is the correct value, isn't it? This way I can ask if there is a selection by simply asking if the second value equals -1.

Here is the current status as a picture:
![bildschirmfoto - 28 01 2015 - 12 51 50](https://cloud.githubusercontent.com/assets/3997610/5937151/71e94ea0-a6ec-11e4-99ce-a2a4643bf789.png)

